### PR TITLE
Changed FRONT END account ledger references to read as Credit Transfers

### DIFF
--- a/lfucg-exactions/client/js/actions/apiActions.js
+++ b/lfucg-exactions/client/js/actions/apiActions.js
@@ -1327,7 +1327,7 @@ export function getPagination(page) {
             } = activeForm;
             
             if (!page) {
-                if (currentPage === '/account-ledger/') {
+                if (currentPage === '/credit-transfer/') {
                     return '/ledger/?paginatePage';
                 }
 
@@ -1360,7 +1360,7 @@ export function searchQuery() {
 
             let query_all = `${activeForm.currentPage}?paginatePage`;
 
-            if (activeForm.currentPage === '/account-ledger/') {
+            if (activeForm.currentPage === '/credit-transfer/') {
                 query_all = '/ledger/?paginatePage';
             }
 

--- a/lfucg-exactions/client/js/components/AccountLedgerExisting.js
+++ b/lfucg-exactions/client/js/components/AccountLedgerExisting.js
@@ -70,7 +70,7 @@ class AccountLedgerExisting extends React.Component {
                             <div className="col-xs-12 col-sm-5 col-md-3 col-sm-offset-7 col-md-offset-9">
                                 <div className="col-xs-5">
                                     {currentUser && currentUser.permissions && currentUser.permissions.accountledger &&
-                                        <Link to={`account-ledger/form/${accountLedger.id}`} aria-label="Edit">
+                                        <Link to={`credit-transfer/form/${accountLedger.id}`} aria-label="Edit">
                                             <i className="fa fa-pencil-square link-icon col-xs-4" aria-hidden="true" />
                                             <div className="col-xs-7 link-label">
                                                 Edit
@@ -79,7 +79,7 @@ class AccountLedgerExisting extends React.Component {
                                     }
                                 </div>
                                 <div className="col-xs-5 ">
-                                    <Link to={`account-ledger/summary/${accountLedger.id}`} aria-label="Summary">
+                                    <Link to={`credit-transfer/summary/${accountLedger.id}`} aria-label="Summary">
                                         <i className="fa fa-file-text link-icon col-xs-4" aria-hidden="true" />
                                         <div className="col-xs-7 link-label">
                                             Summary
@@ -115,7 +115,7 @@ class AccountLedgerExisting extends React.Component {
 
                 <div className="form-header">
                     <div className="container">
-                        <h1>ACCOUNT LEDGERS - EXISTING</h1>
+                        <h1>CREDIT TRANSFERS - EXISTING</h1>
                     </div>
                 </div>
 

--- a/lfucg-exactions/client/js/components/AccountLedgerForm.js
+++ b/lfucg-exactions/client/js/components/AccountLedgerForm.js
@@ -99,11 +99,11 @@ class AccountLedgerForm extends React.Component {
 
                 <div className="form-header">
                     <div className="container">
-                        <h1>ACCOUNT LEDGERS - CREATE</h1>
+                        <h1>CREDIT TRANSFERS - CREATE</h1>
                     </div>
                 </div>
 
-                <Breadcrumbs route={this.props.route} parent_link={'account-ledger'} parent_name={'Account Ledgers'} />
+                <Breadcrumbs route={this.props.route} parent_link={'credit-transfer'} parent_name={'Credit Transfers'} />
 
                 <div className="inside-body">
                     <div className="container">
@@ -445,15 +445,15 @@ function mapDispatchToProps(dispatch, params) {
             if (selectedAccountLedger) {
                 dispatch(putAccountLedger(selectedAccountLedger))
                 .then(() => {
-                    hashHistory.push(`account-ledger/summary/${selectedAccountLedger}`);
+                    hashHistory.push(`credit-transfer/summary/${selectedAccountLedger}`);
                 });
             } else {
                 dispatch(postAccountLedger())
                 .then((data_post) => {
                     if (event === 'lot') {
-                        hashHistory.push(`account-ledger/summary/${data_post.response.id}`);
+                        hashHistory.push(`credit-transfer/summary/${data_post.response.id}`);
                     } else if (event === 'plat') {
-                        hashHistory.push('account-ledger');
+                        hashHistory.push('credit-transfer');
                     }
                 });
             }

--- a/lfucg-exactions/client/js/components/AccountLedgerSummary.js
+++ b/lfucg-exactions/client/js/components/AccountLedgerSummary.js
@@ -29,11 +29,11 @@ class AccountLedgerSummary extends React.Component {
 
                 <div className="form-header">
                     <div className="container">
-                        <h1>ACCOUNT LEDGER - SUMMARY</h1>
+                        <h1>CREDIT TRANSFER - SUMMARY</h1>
                     </div>
                 </div>
 
-                <Breadcrumbs route={this.props.route} parent_link={'account-ledger'} parent_name={'Account Ledgers'} />
+                <Breadcrumbs route={this.props.route} parent_link={'credit-transfer'} parent_name={'Credit Transfers'} />
 
                 <div className="inside-body">
                     <div className="container">
@@ -49,7 +49,7 @@ class AccountLedgerSummary extends React.Component {
                                 <div className="row section-heading" role="tab" id="headingAccountLedgerInfo">
                                     <div className="col-xs-1 caret-indicator" />
                                     <div className="col-xs-10">
-                                        <h2>Account Ledger Information</h2>
+                                        <h2>Credit Transfer Information</h2>
                                     </div>
                                 </div>
                             </a>
@@ -64,7 +64,7 @@ class AccountLedgerSummary extends React.Component {
                                         <div className="col-xs-12 col-sm-5 col-md-3 col-sm-offset-7 col-md-offset-9">
                                             <div className="col-xs-5 col-xs-offset-5">
                                                 {currentUser && currentUser.permissions && currentUser.permissions.accountledger &&
-                                                    <Link to={`account-ledger/form/${accountLedgers.id}`} aria-label="Edit">
+                                                    <Link to={`credit-transfer/form/${accountLedgers.id}`} aria-label="Edit">
                                                         <i className="fa fa-pencil-square link-icon col-xs-4" aria-hidden="true" />
                                                         <div className="col-xs-7 link-label">
                                                             Edit

--- a/lfucg-exactions/client/js/components/AccountSummary.js
+++ b/lfucg-exactions/client/js/components/AccountSummary.js
@@ -198,7 +198,7 @@ class AccountSummary extends React.Component {
                             <div className="col-xs-12 col-sm-5 col-md-3 col-sm-offset-7 col-md-offset-9">
                                 <div className="col-xs-5">
                                     {currentUser && currentUser.permissions && currentUser.permissions.accountledger &&
-                                        <Link to={`account-ledger/form/${accountLedger.id}`} aria-label="Edit">
+                                        <Link to={`credit-transfer/form/${accountLedger.id}`} aria-label="Edit">
                                             <i className="fa fa-pencil-square link-icon col-xs-4" aria-hidden="true" />
                                             <div className="col-xs-7 link-label">
                                                 Edit
@@ -207,7 +207,7 @@ class AccountSummary extends React.Component {
                                     }
                                 </div>
                                 <div className="col-xs-5 ">
-                                    <Link to={`account-ledger/summary/${accountLedger.id}`} aria-label="Summary">
+                                    <Link to={`credit-transfer/summary/${accountLedger.id}`} aria-label="Summary">
                                         <i className="fa fa-file-text link-icon col-xs-4" aria-hidden="true" />
                                         <div className="col-xs-7 link-label">
                                             Summary
@@ -447,7 +447,7 @@ class AccountSummary extends React.Component {
                                         <div className="row section-heading" role="tab" id="headingAccountLedgers">
                                             <div className="col-xs-1 caret-indicator" />
                                             <div className="col-xs-10">
-                                                <h2>Account Ledgers</h2>
+                                                <h2>Credit Transfers</h2>
                                             </div>
                                         </div>
                                     </a>
@@ -466,7 +466,7 @@ class AccountSummary extends React.Component {
                                 </div>
                             ) : (
                                 <div className="row section-heading" role="tab" id="headingAccountLedgers">
-                                    <h2>Account Ledgers - None</h2>
+                                    <h2>Credit Transfers - None</h2>
                                 </div>
                             )}
 

--- a/lfucg-exactions/client/js/components/AgreementSummary.js
+++ b/lfucg-exactions/client/js/components/AgreementSummary.js
@@ -121,7 +121,7 @@ class AgreementSummary extends React.Component {
                             <div className="col-xs-12 col-sm-5 col-md-3 col-sm-offset-7 col-md-offset-9">
                                 <div className="col-xs-5">
                                     {currentUser && currentUser.permissions && currentUser.permissions.accountledger &&
-                                        <Link to={`account-ledger/form/${accountLedger.id}`} aria-label="Edit">
+                                        <Link to={`credit-transfer/form/${accountLedger.id}`} aria-label="Edit">
                                             <i className="fa fa-pencil-square link-icon col-xs-4" aria-hidden="true" />
                                             <div className="col-xs-7 link-label">
                                                 Edit
@@ -130,7 +130,7 @@ class AgreementSummary extends React.Component {
                                     }
                                 </div>
                                 <div className="col-xs-5 ">
-                                    <Link to={`account-ledger/summary/${accountLedger.id}`} aria-label="Summary">
+                                    <Link to={`credit-transfer/summary/${accountLedger.id}`} aria-label="Summary">
                                         <i className="fa fa-file-text link-icon col-xs-4" aria-hidden="true" />
                                         <div className="col-xs-7 link-label">
                                             Summary
@@ -368,7 +368,7 @@ class AgreementSummary extends React.Component {
                                         <div className="row section-heading" role="tab" id="headingAccountLedgers">
                                             <div className="col-xs-1 caret-indicator" />
                                             <div className="col-xs-10">
-                                                <h2>Account Ledgers</h2>
+                                                <h2>Credit Transfers</h2>
                                             </div>
                                         </div>
                                     </a>
@@ -387,7 +387,7 @@ class AgreementSummary extends React.Component {
                                 </div>
                             ) : (
                                 <div className="row section-heading" role="tab" id="headingAccountLedgers">
-                                    <h2>Account Ledgers - None</h2>
+                                    <h2>Credit Transfers - None</h2>
                                 </div>
                             )}
 

--- a/lfucg-exactions/client/js/components/DashboardPage.js
+++ b/lfucg-exactions/client/js/components/DashboardPage.js
@@ -37,8 +37,8 @@ class DashboardPage extends React.Component {
                                 <p>Lexington agreements based on resolution numbers or memos.</p>
                             </div>
                             <div className="col-md-4 col-sm-6">
-                                <Link to="account-ledger" role="link"><h2 className="in-page-link">Credit Transfers</h2></Link>
-                                <p>Lexington account ledgers.  Credit transfers, new credit awards, and credit payments.</p>
+                                <Link to="credit-transfer" role="link"><h2 className="in-page-link">Credit Transfers</h2></Link>
+                                <p>Lexington account ledgers for credits.  Credit transfers, new credit awards, and credit payments.</p>
                             </div>
                             <div className="col-md-4 col-sm-6">
                                 <Link to="payment" role="link"><h2 className="in-page-link">Monetary Payments</h2></Link>

--- a/lfucg-exactions/client/js/components/LotSummary.js
+++ b/lfucg-exactions/client/js/components/LotSummary.js
@@ -94,7 +94,7 @@ class LotSummary extends React.Component {
                             <div className="col-xs-12 col-sm-5 col-md-3 col-sm-offset-7 col-md-offset-9">
                                 <div className="col-xs-5">
                                     {currentUser && currentUser.permissions && currentUser.permissions.accountledger &&
-                                        <Link to={`account-ledger/form/${accountLedger.id}`} aria-label="Edit">
+                                        <Link to={`credit-transfer/form/${accountLedger.id}`} aria-label="Edit">
                                             <i className="fa fa-pencil-square link-icon col-xs-4" aria-hidden="true" />
                                             <div className="col-xs-7 link-label">
                                                 Edit
@@ -103,7 +103,7 @@ class LotSummary extends React.Component {
                                     }
                                 </div>
                                 <div className="col-xs-5 ">
-                                    <Link to={`account-ledger/summary/${accountLedger.id}`} aria-label="Summary">
+                                    <Link to={`credit-transfer/summary/${accountLedger.id}`} aria-label="Summary">
                                         <i className="fa fa-file-text link-icon col-xs-4" aria-hidden="true" />
                                         <div className="col-xs-7 link-label">
                                             Summary
@@ -490,7 +490,7 @@ class LotSummary extends React.Component {
                                             <div className="row section-heading" role="tab" id="headingAccountLedgers">
                                                 <div className="col-xs-1 caret-indicator" />
                                                 <div className="col-xs-10">
-                                                    <h2>Account Ledgers</h2>
+                                                    <h2>Credit Transfers</h2>
                                                 </div>
                                             </div>
                                         </a>
@@ -509,7 +509,7 @@ class LotSummary extends React.Component {
                                     </div>
                                 ) : (
                                     <div className="row section-heading" role="tab" id="headingAccountLedgers">
-                                        <h2>Account Ledgers - None</h2>
+                                        <h2>Credit Transfers - None</h2>
                                     </div>
                                 )}
                             </div>

--- a/lfucg-exactions/client/js/dashboard.js
+++ b/lfucg-exactions/client/js/dashboard.js
@@ -114,10 +114,10 @@ ReactDOM.render(
             <Route path="project-cost/form" component={ProjectCostForm} name="Project Cost Form" />
             <Route path="project-cost/form/:id" component={ProjectCostForm} name="Current Project Cost Form" />
 
-            <Route path="account-ledger" component={AccountLedgerExisting} name="Existing Account Ledgers" />
-            <Route path="account-ledger/summary/:id" component={AccountLedgerSummary} name="Account Ledger Summary" />
-            <Route path="account-ledger/form" component={AccountLedgerForm} name="Account Ledger Form" />
-            <Route path="account-ledger/form/:id" component={AccountLedgerForm} name="Current Account Ledger Form" />
+            <Route path="credit-transfer" component={AccountLedgerExisting} name="Existing Credit Transfers" />
+            <Route path="credit-transfer/summary/:id" component={AccountLedgerSummary} name="Credit Transfer Summary" />
+            <Route path="credit-transfer/form" component={AccountLedgerForm} name="Credit Transfer Form" />
+            <Route path="credit-transfer/form/:id" component={AccountLedgerForm} name="Current Credit Transfer Form" />
 
         </Router>
     </Provider>,

--- a/lfucg-exactions/client/js/reducers/accountLedgersReducer.js
+++ b/lfucg-exactions/client/js/reducers/accountLedgersReducer.js
@@ -31,7 +31,7 @@ const accountLedgersReducer = (state = [], action) => {
         const prev = action.response.prev;
         if ((next != null && next.startsWith('/ledger')) ||
             (prev != null && prev.startsWith('/ledger')) ||
-            (window.location.hash === '#/account-ledger')) {
+            (window.location.hash === '#/credit-transfer')) {
             return action.response;
         }
         return state;


### PR DESCRIPTION
1. What is this for? Changing verbiage on Account Ledgers to Credit Transfers
2. What caused the issue? Client request for clarity
3. What was your approach? All of the forward-facing references to the model (Account Ledgers) now says "Credit Transfers". 