### PR TITLE
Ex 112 account ledgers not showing

### DIFF
--- a/lfucg-exactions/client/js/actions/apiActions.js
+++ b/lfucg-exactions/client/js/actions/apiActions.js
@@ -1225,7 +1225,7 @@ export function getAccountAccountLedgers(selectedAccount) {
     return {
         type: API_CALL,
         endpoint: GET_ACCOUNT_ACCOUNT_LEDGERS,
-        url: `/ledger/?account_from=${selectedAccount}&account_to=${selectedAccount}`,
+        url: `/ledger/?acct=${selectedAccount}`,
     };
 }
 

--- a/lfucg-exactions/client/js/components/AccountSummary.js
+++ b/lfucg-exactions/client/js/components/AccountSummary.js
@@ -220,7 +220,7 @@ class AccountSummary extends React.Component {
                             <p className="col-sm-4 col-xs-6">Account From: {accountLedger.account_from.account_name}</p>
                             <p className="col-sm-4 col-xs-6">Account To: {accountLedger.account_to.account_name}</p>
                             <p className="col-sm-4 col-xs-6">Agreement: {accountLedger.agreement.resolution_number}</p>
-                            <p className="col-xs-12">Lot: {accountLedger.lot.address_full}</p>
+                            <p className="col-xs-12">Lot: {accountLedger.lot && accountLedger.lot.address_full}</p>
                         </div>
                     </div>
                 );

--- a/lfucg-exactions/client/js/components/LotForm.js
+++ b/lfucg-exactions/client/js/components/LotForm.js
@@ -485,7 +485,6 @@ function mapDispatchToProps(dispatch, params) {
                         dues_open_space_dev: data_lot.response.dues_open_space_dev,
                         dues_open_space_own: data_lot.response.dues_open_space_own,
                         first_section: true,
-                        show_exactions: false,
                     };
                     dispatch(formUpdate(update));
                     if (data_lot.response.account) {

--- a/lfucg-exactions/server/accounts/viewsets.py
+++ b/lfucg-exactions/server/accounts/viewsets.py
@@ -232,8 +232,6 @@ class AccountLedgerViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         queryset = AccountLedger.objects.all()
         PageNumberPagination.page_size = 0
-        print('hello from the account ledgers')
-        print(self.request.query_params)
         paginatePage = self.request.query_params.get('paginatePage', None)
         pageSize = self.request.query_params.get('pageSize', settings.PAGINATION_SIZE)
         
@@ -248,7 +246,6 @@ class AccountLedgerViewSet(viewsets.ModelViewSet):
         account_set = self.request.query_params.get('acct', None)
         if account_set is not None:
             queryset = queryset.filter(Q(account_from=account_set) | Q(account_to=account_set))
-            print(queryset)
 
         agreement_set = self.request.query_params.get('agreement', None)
         if agreement_set is not None:

--- a/lfucg-exactions/server/accounts/viewsets.py
+++ b/lfucg-exactions/server/accounts/viewsets.py
@@ -232,7 +232,8 @@ class AccountLedgerViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         queryset = AccountLedger.objects.all()
         PageNumberPagination.page_size = 0
-
+        print('hello from the account ledgers')
+        print(self.request.query_params)
         paginatePage = self.request.query_params.get('paginatePage', None)
         pageSize = self.request.query_params.get('pageSize', settings.PAGINATION_SIZE)
         
@@ -244,9 +245,10 @@ class AccountLedgerViewSet(viewsets.ModelViewSet):
         if lot_set is not None:
             queryset = queryset.filter(lot=lot_set)
 
-        account_from_set = self.request.query_params.get('account_from', None)
-        if account_from_set is not None:
-            queryset = queryset.filter(account_from=account_from_set)
+        account_set = self.request.query_params.get('acct', None)
+        if account_set is not None:
+            queryset = queryset.filter(Q(account_from=account_set) | Q(account_to=account_set))
+            print(queryset)
 
         agreement_set = self.request.query_params.get('agreement', None)
         if agreement_set is not None:

--- a/lfucg-exactions/server/accounts/viewsets.py
+++ b/lfucg-exactions/server/accounts/viewsets.py
@@ -70,7 +70,7 @@ class AgreementViewSet(viewsets.ModelViewSet):
         account_id_set = self.request.query_params.get('account_id', None)
         if account_id_set is not None:
             queryset = queryset.filter(account_id=account_id_set)
-            
+
         if paginatePage is not None:
             pagination_class = PageNumberPagination
             PageNumberPagination.page_size = pageSize


### PR DESCRIPTION
This issue was the advanced searching filter fields were blocking some of the information coming from the front end to get the appropriate results in the backend. 

I attempted to change the logic by adding an 'or' to the filtering based on the query parameters. I also changed the query params sent from the front end to not conflict with the backend stuff. 