### PR TITLE
added sentry for tracking posts, 400s, 500s

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,3 +2,5 @@
 
 # POSTMARK_API_KEY=<postmark-api-key>
 # EMAIL_BACKEND=postmarker.django.EmailBackend
+
+# SENTRY_API_DSN="https://this_is_the_url_provided_by_sentry_for_shipping_logs.ingest.us.sentry.io/some_sort_of_key"

--- a/backend/base/middleware/log400.py
+++ b/backend/base/middleware/log400.py
@@ -1,0 +1,38 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+class Log400Midleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        request_body = b""
+        if request.body:
+            request_body = request.body
+
+        response = self.get_response(request)
+
+        if response.status_code == 400:
+            self._log_bad_request(request, request_body, response)
+
+        return response
+
+    def _log_bad_request(self, request, request_body, response):
+        headers = {k: v for k, v in request.META.items() if k.startswith('HTTP_')}
+
+        try:
+            response_body = response.content.decode('utf-8', errors='replace')
+        except AttributeError:
+            response_body = "[Streaming/Large Response or Unreadable Content]"
+
+        log_data = {
+            'log_source': 'middleware',
+            "path": request.path,
+            "method": request.method,
+            'query_string': request.GET.urlencode(),
+            "request_headers": headers,
+            "request_body": request_body.decode('utf-8', errors='replace'),
+            "response_body": response_body,
+        }
+        logger.warning(f"HTTP 400 Bad Request", extra=log_data)

--- a/backend/base/middleware/log500.py
+++ b/backend/base/middleware/log500.py
@@ -1,0 +1,30 @@
+import logging
+import traceback
+
+logger = logging.getLogger(__name__)
+
+class Log500ErrorsMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        return response
+
+    def process_exception(self, request, ex):
+        headers = {k: v for k, v in request.META.items() if k.startswith('HTTP_')}
+        tb = ''.join(traceback.TracebackException.from_exception(ex).format())
+        logger.error(ex, exc_info=1, extra={
+            'log_source': 'middleware',
+            'path': request.path,
+            'method': request.method,
+            'user': request.user.email if request.user else None,
+            'view': request.resolver_match.view_name,
+            'query_string': request.GET.urlencode(),
+            "request_headers": headers,
+            'request_body': request.body,
+            'request_id': request.META.get('HTTP_X_REQUEST_ID'),
+            'stack_trace': tb,
+        })
+        return None
+

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -60,6 +60,8 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "simple_history.middleware.HistoryRequestMiddleware",
+    "base.middleware.log500.Log500ErrorsMiddleware",
+    "base.middleware.log400.Log400Midleware",
 ]
 
 ROOT_URLCONF = "base.urls"

--- a/backend/config/settings/local.py
+++ b/backend/config/settings/local.py
@@ -1,5 +1,6 @@
 from .base import *
 from .base import env
+import sentry_sdk
 
 DEBUG = True
 
@@ -34,3 +35,16 @@ EMAIL_BACKEND = env(
 )
 
 POSTMARK_API_KEY = env("POSTMARK_API_KEY", default="fake_key")
+
+SENTRY_API_DSN = env("SENTRY_API_DSN", default=None)
+if(SENTRY_API_DSN):
+    sentry_sdk.init(
+        dsn=SENTRY_API_DSN,
+        environment="local",
+        # Add data like request headers and IP for users,
+        # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+        send_default_pii=True,
+        # Enable sending logs to Sentry
+        enable_logs=True,
+        add_full_stack=True,
+    )

--- a/backend/config/settings/production.py
+++ b/backend/config/settings/production.py
@@ -1,4 +1,5 @@
 from config import ecs
+import sentry_sdk
 
 from .base import *
 from .base import env
@@ -85,3 +86,16 @@ LOGGING = {
         },
     },
 }
+
+SENTRY_API_DSN = env("SENTRY_API_DSN", default=None)
+if(SENTRY_API_DSN):
+    sentry_sdk.init(
+        dsn=SENTRY_API_DSN,
+        environment="production",
+        # Add data like request headers and IP for users,
+        # see https://docs.sentry.io/platforms/python/data-management/data-collected/ for more info
+        send_default_pii=True,
+        # Enable sending logs to Sentry
+        enable_logs=True,
+        add_full_stack=True,
+    )

--- a/backend/requirements/base.txt
+++ b/backend/requirements/base.txt
@@ -34,6 +34,7 @@ pytz==2020.1
 s3transfer==0.1.11
 sendgrid==3.6.3
 sendgrid-django==4.0.0
+sentry-sdk==2.64.0
 six==1.12.0
 sqlparse==0.2.3
 Unipath==1.1

--- a/cdk/lib/app-env.ts
+++ b/cdk/lib/app-env.ts
@@ -19,6 +19,7 @@ export const configSecretFields = [
   'AWS_ACCESS_KEY_ID',
   'AWS_SECRET_ACCESS_KEY',
   'POSTMARK_API_KEY',
+  'SENTRY_API_DSN',
 ] as const;
 
 type AppConfig = typeof configSecretFields;


### PR DESCRIPTION
Add sentry for logging.
* log exceptions in django routes (any 500 should log one)
* log bad requests, both request body and response (any 400)
* add env field for configuring/enabling sentry
* use sentry as generic python package, not dependent on legacy Django